### PR TITLE
Use personal ESLint config and Travis CI linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - node
   - lts/*
+script:
+  - npm test
+  - npm run lint

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
-    "mocha": "^5.2.0"
+	"eslint-config-haykam": "^1.3.0",
+	"eslint-plugin-extra-rules": "0.0.0-development",
+	"eslint-plugin-html": "^4.0.5",
+	"eslint-plugin-json": "^1.2.1",
+	"eslint-plugin-markdown": "^1.0.0-beta.6",
+	"eslint-plugin-unicorn": "^5.0.0"
+    "mocha": "^5.2.0",
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "vertical-pad",
-  "version": "1.0.0",
-  "description": "Pad the number of lines in a string.",
-  "main": "index.js",
-  "scripts": {
+	"name": "vertical-pad",
+	"version": "1.0.0",
+	"description": "Pad the number of lines in a string.",
+	"main": "index.js",
+	"scripts": {
 		"lint": "eslint \"./**/*.js\"",
-    "test": "mocha test.js"
-  },
-  "keywords": [
-    "verticalpad",
-    "vertical",
-    "pad",
-    "newline",
-    "padding",
-    "string",
-    "repeat",
-    "lines"
-  ],
-  "author": "haykam821",
-  "license": "MIT",
-  "devDependencies": {
-    "chai": "^4.1.2",
-    "eslint": "^4.19.1",
-	"eslint-config-haykam": "^1.3.0",
-	"eslint-plugin-extra-rules": "0.0.0-development",
-	"eslint-plugin-html": "^4.0.5",
-	"eslint-plugin-json": "^1.2.1",
-	"eslint-plugin-markdown": "^1.0.0-beta.6",
-	"eslint-plugin-unicorn": "^5.0.0"
-    "mocha": "^5.2.0",
-  }
+		"test": "mocha test.js"
+	},
+	"keywords": [
+		"verticalpad",
+		"vertical",
+		"pad",
+		"newline",
+		"padding",
+		"string",
+		"repeat",
+		"lines"
+	],
+	"author": "haykam821",
+	"license": "MIT",
+	"devDependencies": {
+		"chai": "^4.1.2",
+		"eslint": "^4.19.1",
+		"eslint-config-haykam": "^1.3.0",
+		"eslint-plugin-extra-rules": "0.0.0-development",
+		"eslint-plugin-html": "^4.0.5",
+		"eslint-plugin-json": "^1.2.1",
+		"eslint-plugin-markdown": "^1.0.0-beta.6",
+		"eslint-plugin-unicorn": "^5.0.0",
+		"mocha": "^5.2.0",
+	}
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Pad the number of lines in a string.",
   "main": "index.js",
   "scripts": {
+		"lint": "eslint \"./**/*.js\"",
     "test": "mocha test.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
 		"eslint-plugin-json": "^1.2.1",
 		"eslint-plugin-markdown": "^1.0.0-beta.6",
 		"eslint-plugin-unicorn": "^5.0.0",
-		"mocha": "^5.2.0",
+		"mocha": "^5.2.0"
 	}
 }


### PR DESCRIPTION
This pull request removes the entire ESLint config, instead using [the personal config](https://github.com/haykam821/ESLint-Config-Haykam) I made. Also, it makes `npm run lint` run ESLint, and does this via [Travis CI](https://travis-ci.com/haykam821/Vertical-Pad/) automatically.